### PR TITLE
Use digest for Chainguard Image

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM cgr.dev/chainguard/go:1.19.3 AS build
+FROM cgr.dev/chainguard/go:1.20@sha256:c99d028201a2a61008be1b619f6c57c47b845b34e0d16489f7187c9802a9cd07 AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
We're making some changes to the public tier of Chainguard Images.

Starting August 16, 2023 public users will no longer be able to pull images from our registry (cgr.dev/chainguard) by tags other than latest or latest-dev. Please see [the announcement](https://www.chainguard.dev/unchained/scaling-chainguard-images-with-a-growing-catalog-and-proactive-security-updates) for more information.

This PR will move one of your images to use a digest, which will continue to work post August 16th. The other image (static) is using latest which will also continue to work.

Please see [the migration guide](https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users) for full details on your options.